### PR TITLE
【確認待ち】applicantLocationRequirements と directApply を追加

### DIFF
--- a/blocks/vk-google-job-posting-manager-block.php
+++ b/blocks/vk-google-job-posting-manager-block.php
@@ -287,7 +287,7 @@ function vgjpm_render_job_posting_info( $post_id, $style, $className ) {
 	$separater = __( ' - ', 'vk-google-job-posting-manager' );
 	$separater = apply_filters( 'vgjpm_salary_separater', $separater );
 
-	$html .= vgjpm_get_label_of_array( array( $custom_fields['vkjp_unitText'] ) );
+	$html .= vgjpm_get_label_of_array( array( $custom_fields['vkjp_unitText'] ) ) . ' ';
 	$html .= vgjpm_salary_and_currency( $args_min ) . $separater . vgjpm_salary_and_currency( $args_max );
 	$html .= $tags['content_after'];
 

--- a/inc/custom-field-builder/custom-field-builder-config.php
+++ b/inc/custom-field-builder/custom-field-builder-config.php
@@ -153,11 +153,17 @@ class VGJPM_Custom_Field_Job_Post extends VK_Custom_Field_Builder {
 				'description' => __( 'Please check it, only if you allow employees full remote work.', 'vk-google-job-posting-manager' ),
 				'required'    => false,
 			),
+			'vkjp_applicantLocationRequirements_name'        => array(
+				'label'       => __( 'Country of Remote Work Location', 'vk-google-job-posting-manager' ),
+				'type'        => 'text',
+				'description' => __( 'Example : USA', 'vk-google-job-posting-manager' ),
+				'required'    => false,
+			),
 			'vkjp_name'                   => array(
 				'label'       => __( 'Hiring Organization Name', 'vk-google-job-posting-manager' ),
 				'type'        => 'text',
 				'description' => __( 'Example : Vektor,Inc. Do not include address of organization', 'vk-google-job-posting-manager' ),
-				'required'    => false,
+				'required'    => true,
 			),
 			'vkjp_sameAs'                 => array(
 				'label'       => __( 'Hiring Organization Website', 'vk-google-job-posting-manager' ),
@@ -211,6 +217,15 @@ class VGJPM_Custom_Field_Job_Post extends VK_Custom_Field_Builder {
 				'label'       => __( 'Company Identifier Number', 'vk-google-job-posting-manager' ),
 				'type'        => 'text',
 				'description' => __( 'The hiring organization\'s unique identifier number for the job posting. <br> Please enter a unique number id whatever you want. Example : 1234567', 'vk-google-job-posting-manager' ),
+				'required'    => false,
+			),
+			'vkjp_directApply'    => array(
+				'label'       => __( 'Direct Apply', 'vk-google-job-posting-manager' ),
+				'type'        => 'checkbox',
+				'options'     => array(
+					'true' => __( 'You can apply from this page', 'vk-google-job-posting-manager' ),
+				),
+				'description' => __( 'Please check it, only if you set apply form on this page.', 'vk-google-job-posting-manager' ),
 				'required'    => false,
 			),
 		);

--- a/vk-google-job-posting-manager.php
+++ b/vk-google-job-posting-manager.php
@@ -520,9 +520,8 @@ function vgjpm_generate_jsonLD( $custom_fields ) {
 	"jobLocationType": "' . esc_attr( $custom_fields['vkjp_jobLocationType'] ) . '",
 	"applicantLocationRequirements": {
 		"@type": "Country",
-		"name":' . esc_attr( $custom_fields['vkjp_applicantLocationRequirements_name'] ) . '",
-	  },
-	}';
+		"name": "' . esc_attr( $custom_fields['vkjp_applicantLocationRequirements_name'] ) . '"
+	},';
 	}
 	$JSON .= '
 	"baseSalary": {
@@ -534,10 +533,10 @@ function vgjpm_generate_jsonLD( $custom_fields ) {
 			"maxValue": ' . esc_attr( $custom_fields['vkjp_maxValue'] ) . ',
 			"unitText": "' . esc_attr( $custom_fields['vkjp_unitText'] ) . '"
 		}
-	}';
+	},';
 	if ( $custom_fields['vkjp_directApply'] ) {
 		$JSON .= '
-	"directApply": true,';
+	"directApply": true';
 	}
 	$JSON .= '
 }

--- a/vk-google-job-posting-manager.php
+++ b/vk-google-job-posting-manager.php
@@ -104,6 +104,8 @@ function vgjpm_get_common_customfields_config() {
 		'vkjp_unitText',
 		'vkjp_validThrough',
 		'vkjp_identifier',
+		'vkjp_applicantLocationRequirements_name',
+		'vkjp_directApply'
 		// 'vkjp_experienceRequirements',
 	);
 	$labels_ordered = array();
@@ -136,6 +138,8 @@ function vgjpm_get_common_customfields_config() {
 		'vkjp_streetAddress',
 		'vkjp_validThrough',
 		'vkjp_identifier',
+		'vkjp_applicantLocationRequirements_name',
+		'vkjp_directApply'
 	);
 
 	foreach ( $labels_ordered as $key => $value ) {
@@ -513,7 +517,12 @@ function vgjpm_generate_jsonLD( $custom_fields ) {
 	},';
 	if ( $custom_fields['vkjp_jobLocationType'] ) {
 		$JSON .= '
-	"jobLocationType": "' . esc_attr( $custom_fields['vkjp_jobLocationType'] ) . '",';
+	"jobLocationType": "' . esc_attr( $custom_fields['vkjp_jobLocationType'] ) . '",
+	"applicantLocationRequirements": {
+		"@type": "Country",
+		"name":' . esc_attr( $custom_fields['vkjp_applicantLocationRequirements_name'] ) . '",
+	  },
+	}';
 	}
 	$JSON .= '
 	"baseSalary": {
@@ -525,7 +534,12 @@ function vgjpm_generate_jsonLD( $custom_fields ) {
 			"maxValue": ' . esc_attr( $custom_fields['vkjp_maxValue'] ) . ',
 			"unitText": "' . esc_attr( $custom_fields['vkjp_unitText'] ) . '"
 		}
+	}';
+	if ( $custom_fields['vkjp_directApply'] ) {
+		$JSON .= '
+	"directApply": true,';
 	}
+	$JSON .= '
 }
 </script>
 ';


### PR DESCRIPTION
- applicantLocationRequirements の国版（リモートワークなのに県規模・市町村規模で制限する必要性を感じなかったため）
- directApply

上記を追加しました。

【確認方法】

1. 適当に求人情報を作って投稿してそのページを表示
2. 該当記事のソースコードを表示し head 領域の最下部に JSON-LD があるのを確認
3. https://developers.google.com/search/docs/advanced/structured-data/job-posting?hl=ja に移動し「リッチリザルト テストで試す」をクリック
4. 3 のページで JSON-LD のコードをプラグインで出力したものに書き換え
テスト結果が通れば OK