### PR TITLE
[ 機能追加 ] 求人情報ブロックで WordPress.org 翻訳対応を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,8 @@ You can overwrite common fields value by fill out each post's custom fields.
 
 == Changelog ==
 
+[ Add feature ] Added i18n support for "Job Posting" block to enable WordPress.org translations.
+
 = 1.2.20 =
 * [ Outer ] Update block to use apiVersion: 3 for iframe-based editing
 

--- a/vk-google-job-posting-manager.php
+++ b/vk-google-job-posting-manager.php
@@ -38,6 +38,18 @@ function vgjpm_load_textdomain() {
 }
 add_action( 'plugins_loaded', 'vgjpm_load_textdomain' );
 
+if ( ! function_exists( 'vgjpm_set_script_translations' ) ) {
+	/**
+	 * Set text domain for JavaScript translations.
+	 */
+	function vgjpm_set_script_translations() {
+		if ( function_exists( 'wp_set_script_translations' ) ) {
+			wp_set_script_translations( 'vk-google-job-posting-manager-block-editor', 'vk-google-job-posting-manager' );
+		}
+	}
+	add_action( 'enqueue_block_editor_assets', 'vgjpm_set_script_translations' );
+}
+
 function vgjpm_activate() {
 	update_option( 'vgjpm_create_jobpost_posttype', 'true' );
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#75 

## どういう変更をしたか？

`vk-google-job-posting-manager.php` に `wp_set_script_translations()` 関数を追加し、ブロックエディタで JavaScript の翻訳を有効化しました。

### 変更前 Before
<img width="1257" height="570" alt="スクリーンショット 2025-11-05 10 23 56" src="https://github.com/user-attachments/assets/c2d5e4f8-125c-4439-8484-73c40fb21d4e" />

### 変更後 After
<img width="1255" height="547" alt="スクリーンショット 2025-11-05 10 25 30" src="https://github.com/user-attachments/assets/dd604507-1692-4001-ab1c-de058b422101" />

## 確認事項

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？ → スキップ


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* WordPress 標準関数の使用確認：`wp_set_script_translations()` は WordPress 6.5+ で対応
* translate.wordpress.org の翻訳データ確認：日本語翻訳が存在することを確認済み

##

## 確認URL

ローカルでは確認できないので、 https://demo.vk-fullsite-installer.com/recruit/ にアップして確認。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

1. WordPress 6.5 以上の環境で、ブロックエディタを開く
2. ブロックスライダーで「求人情報」を検索
3. 「Job Posting」ではなく「**求人情報**」と日本語で表示されることを確認
4. ブロックを追加して右パネルでもが日本語で表示されることを確認

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
