### PR TITLE
[ 開発環境 ] npm run zip コマンドを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:js": "webpack --config webpack2.config.js",
     "lint": "wp-scripts format && wp-scripts lint-js --fix",
     "dist": "composer install --no-dev && npx gulp dist",
+    "zip": "npm run dist && cd dist && zip -r vk-google-job-posting-manager.zip vk-google-job-posting-manager",
     "gulp": "npx gulp",
     "phpunit": "composer install && npx wp-env run tests-cli --env-cwd='wp-content/plugins/vk-google-job-posting-manager' vendor/bin/phpunit -c .phpunit.xml --verbose",
     "test": "bash bin/install-wp-tests.sh wordpress_test root 'wordpress' localhost latest && phpunit"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build:block": "wp-scripts build --config webpack.config.js",
     "build:js": "webpack --config webpack2.config.js",
     "lint": "wp-scripts format && wp-scripts lint-js --fix",
-    "dist": "composer install --no-dev && npx gulp dist",
-    "zip": "npm run dist && PLUGIN_VERSION=$(grep -i 'Version *:' vk-google-job-posting-manager.php | head -n 1 | sed -E 's/^[ *]*Version: *([^ ]*) *$/\\1/i') && cd dist && zip -r vk-google-job-posting-manager_v${PLUGIN_VERSION}.zip vk-google-job-posting-manager",
+    "dist": "composer install --no-dev && npx gulp dist && npm run zip",
+    "zip": "PLUGIN_VERSION=$(grep -i 'Version *:' vk-google-job-posting-manager.php | head -n 1 | sed -E 's/^[ *]*Version: *([^ ]*) *$/\\1/i') && cd dist && zip -r vk-google-job-posting-manager_v${PLUGIN_VERSION}.zip vk-google-job-posting-manager",
     "gulp": "npx gulp",
     "phpunit": "composer install && npx wp-env run tests-cli --env-cwd='wp-content/plugins/vk-google-job-posting-manager' vendor/bin/phpunit -c .phpunit.xml --verbose",
     "test": "bash bin/install-wp-tests.sh wordpress_test root 'wordpress' localhost latest && phpunit"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:js": "webpack --config webpack2.config.js",
     "lint": "wp-scripts format && wp-scripts lint-js --fix",
     "dist": "composer install --no-dev && npx gulp dist",
-    "zip": "npm run dist && cd dist && zip -r vk-google-job-posting-manager.zip vk-google-job-posting-manager",
+    "zip": "npm run dist && PLUGIN_VERSION=$(grep -i 'Version *:' vk-google-job-posting-manager.php | head -n 1 | sed -E 's/^[ *]*Version: *([^ ]*) *$/\\1/i') && cd dist && zip -r vk-google-job-posting-manager_v${PLUGIN_VERSION}.zip vk-google-job-posting-manager",
     "gulp": "npx gulp",
     "phpunit": "composer install && npx wp-env run tests-cli --env-cwd='wp-content/plugins/vk-google-job-posting-manager' vendor/bin/phpunit -c .phpunit.xml --verbose",
     "test": "bash bin/install-wp-tests.sh wordpress_test root 'wordpress' localhost latest && phpunit"


### PR DESCRIPTION
## 概要

`npm run zip` コマンドを `package.json` に追加しました。

## 変更内容

- `npm run dist` を実行後、`dist/vk-google-job-posting-manager` ディレクトリを `dist/vk-google-job-posting-manager.zip` として zip 化するコマンドを追加

## テスト

- `npm run zip` を実行し、`dist/vk-google-job-posting-manager.zip` が生成されることを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ビルド完了後に成果物を自動でバージョン付きZIPにまとめる配布用パッケージ作成ステップを追加しました。これにより生成物を簡単に配布・保存できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->