### PR TITLE
[ CI ] Dependabot auto-merge ワークフローを追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for devDeps minor/patch
+        if: |
+          steps.meta.outputs.dependency-type == 'direct:development' &&
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+           steps.meta.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

Dependabot が作成する PR のうち、以下の条件を満たすものを自動マージするワークフローを追加します。

- `dependency-type == direct:development`（devDependencies のみ）
- `update-type == version-update:semver-minor` または `semver-patch`（マイナー/パッチのみ）

メジャー更新や本番依存（dependencies）は従来通り手動確認します。

ブランチ保護で required status checks が設定されている場合は CI グリーンを待ってからマージされます。未設定のリポジトリでは即マージされます。

## 関連

vektor-inc/multi-repo-tasks#8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係の自動更新をマージするGitHub Actionsワークフローを追加しました。特定の条件下で、開発用の依存関係の更新が自動的にマージされるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->