### PR TITLE
[ CI ] auto-merge 条件に indirect を含める

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,9 +15,10 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@v2
 
-      - name: Enable auto-merge for devDeps minor/patch
+      - name: Enable auto-merge for devDeps/indirect minor/patch
         if: |
-          steps.meta.outputs.dependency-type == 'direct:development' &&
+          (steps.meta.outputs.dependency-type == 'direct:development' ||
+           steps.meta.outputs.dependency-type == 'indirect') &&
           (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
            steps.meta.outputs.update-type == 'version-update:semver-patch')
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
パイロット検証の結果、`follow-redirects` のような transitive dep は `dependency-type = indirect` となり auto-merge されなかったため、条件に `indirect` を追加する。

関連: vektor-inc/multi-repo-tasks#8