### PR TITLE
[ 開発環境 ] update スクリプトから gulp 除外フラグを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "Gruntfile.js",
   "author": "Vektor,Inc.",
   "scripts": {
-    "update": "ncu -u -x 'gulp' && rm -rf node_modules package-lock.json && npm install",
+    "update": "ncu -u && rm -rf node_modules package-lock.json && npm install",
     "start": "npm install && npm run build && npm run watch && wp plugin activate vk-google-job-posting-manager && wp browse --wp-admin",
     "watch": "npx gulp watch",
     "build": "npx gulp replace_text_domain && npm run build:block && npm run build:panel && npm run build:css && npm run build:js && npx gulp replace_text_domain",


### PR DESCRIPTION
## Summary

- `package.json` の `update` スクリプトから `-x 'gulp'` を削除し、`npm run update` 実行時に gulp も他の devDep と同じく更新対象にする
- 背景: #74 で gulp を 4 → 5 に更新したため、除外する理由がなくなった（gulp 5 でも `gulpfile.js` の `replace_text_domain` タスクはそのまま動作することを確認済み）

## 確認手順

### 前提条件
- master 最新（#74 マージ済み）に本ブランチをマージした状態

### 手順
1. ローカルで `npm run update` を実行する
   → ✓ `ncu -u` が実行され、`package.json` の devDependencies が最新版に更新される（gulp も含めて除外なく評価される）
2. 続けて `node_modules` / `package-lock.json` が再生成され `npm install` が成功する
   → ✓ エラーなく完了する
3. `npm run build` を実行する
   → ✓ `gulp replace_text_domain` を含む全パイプラインがエラーなく完走する

### デグレ確認
- `update` スクリプト以外の挙動に影響しない変更（1行のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * 開発ツールの依存関係管理プロセスを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->