### PR TITLE
[ 不具合修正 ] 求人情報未入力のページで空の JSON+LD が出力され Search Console エラーを起こす不具合を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,8 @@ You can overwrite common fields value by fill out each post's custom fields.
 
 == Changelog ==
 
+[ Bug Fix ] Fixed an issue where empty JSON-LD was output on pages with no job posting input, causing Search Console errors.
+
 = 1.3.0 =
 [ Spec Change ] Migrate post editor settings UI to block editor sidebar panel
 

--- a/tests/test-default.php
+++ b/tests/test-default.php
@@ -326,14 +326,50 @@ class DefaultTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Title that is null or whitespace-only should not produce JSON-LD either.
-	 * null や空白のみのタイトルでも JSON-LD を出さないことを検証する。
+	 * Title that is null should not produce JSON-LD either.
+	 * null タイトルでも JSON-LD を出さないことを検証する。
 	 */
 	function test_generate_jsonLD_returns_null_when_title_is_null() {
 		$custom_fields = array(
 			'vkjp_title' => null,
 		);
 		$this->assertNull( vgjpm_generate_jsonLD( $custom_fields ) );
+	}
+
+	/**
+	 * Whitespace-only titles must not produce JSON-LD.
+	 *
+	 * Covers half-width space, tab, newline, and full-width space (U+3000)
+	 * which is a common copy-paste artifact in Japanese input.
+	 * 半角スペース・タブ・改行・全角スペース (U+3000) のみのタイトルでも
+	 * JSON-LD が出力されないことを検証する。
+	 *
+	 * @dataProvider provide_whitespace_titles
+	 *
+	 * @param string $title 検証するタイトル文字列。
+	 */
+	function test_generate_jsonLD_returns_null_when_title_is_whitespace_only( $title ) {
+		$custom_fields = array(
+			'vkjp_title' => $title,
+		);
+		$this->assertNull( vgjpm_generate_jsonLD( $custom_fields ) );
+	}
+
+	/**
+	 * Data provider for whitespace-only titles.
+	 * 空白のみタイトルのデータプロバイダ。
+	 *
+	 * @return array
+	 */
+	public function provide_whitespace_titles() {
+		return array(
+			'spaces only'         => array( '   ' ),
+			'tab only'            => array( "\t" ),
+			'newline only'        => array( "\n" ),
+			'mixed whitespace'    => array( " \t\n " ),
+			'full-width space'    => array( '　' ),
+			'mixed full and half' => array( " 　\t" ),
+		);
 	}
 
 	/**

--- a/tests/test-default.php
+++ b/tests/test-default.php
@@ -301,6 +301,42 @@ class DefaultTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Empty title must suppress JSON-LD output entirely.
+	 *
+	 * Sidebar panel may persist empty-string post meta for vkjp_title via
+	 * REST. The generator must reject blank titles to avoid emitting
+	 * payload-less JSON-LD that triggers Search Console errors.
+	 * サイドバーパネル経由で REST に空文字の vkjp_title が保存され得るため、
+	 * 空タイトルでは JSON-LD を一切返さないことを検証する。
+	 */
+	function test_generate_jsonLD_returns_null_when_title_is_empty_string() {
+		$custom_fields = array(
+			'vkjp_title' => '',
+		);
+		$this->assertNull( vgjpm_generate_jsonLD( $custom_fields ) );
+	}
+
+	/**
+	 * Missing title must also suppress JSON-LD output (preserves prior behavior).
+	 * vkjp_title キーが存在しない場合も従来通り出力されないことを検証する。
+	 */
+	function test_generate_jsonLD_returns_null_when_title_is_missing() {
+		$custom_fields = array();
+		$this->assertNull( vgjpm_generate_jsonLD( $custom_fields ) );
+	}
+
+	/**
+	 * Title that is null or whitespace-only should not produce JSON-LD either.
+	 * null や空白のみのタイトルでも JSON-LD を出さないことを検証する。
+	 */
+	function test_generate_jsonLD_returns_null_when_title_is_null() {
+		$custom_fields = array(
+			'vkjp_title' => null,
+		);
+		$this->assertNull( vgjpm_generate_jsonLD( $custom_fields ) );
+	}
+
+	/**
 	 * employmentType should strip stray quotes.
 	 */
 	function test_generate_jsonLD_employmentType_strips_quotes() {

--- a/vk-google-job-posting-manager.php
+++ b/vk-google-job-posting-manager.php
@@ -461,10 +461,45 @@ function vgjpm_save_check_list() {
 	}
 }
 
+/**
+ * Print JobPosting JSON-LD on singular pages of supported post types.
+ * 対象投稿タイプの個別ページで JobPosting JSON-LD を出力する。
+ *
+ * Outputs nothing when the current view is not a singular post of a
+ * supported post type, or when required job-posting fields (title) are
+ * empty. This prevents bogus JSON-LD on archives, the front page, and
+ * empty drafts that could trigger Search Console errors.
+ * 対象投稿タイプの個別ページ以外、または求人情報の必須項目（title）が
+ * 空の場合は出力しない。アーカイブやトップページ、未入力の下書きで
+ * Search Console エラーの原因となる空の JSON-LD が出力されるのを防ぐ。
+ *
+ * @return void
+ */
 function vgjpm_print_jsonLD_in_footer() {
+	// Only emit JSON-LD on singular views; archives and the front page
+	// must never carry a JobPosting payload.
+	// 個別ページのみで出力する。アーカイブやフロントページに
+	// JobPosting の JSON-LD を出してはいけない。
+	if ( ! is_singular() ) {
+		return;
+	}
+
+	// Restrict output to post types that are explicitly enabled for the
+	// job posting metabox / sidebar panel. Falls back gracefully when the
+	// helper is unavailable (older include order, etc.).
+	// 求人情報メタボックス/サイドバーパネルが有効な投稿タイプのみで
+	// 出力する。ヘルパー未定義時は安全側に倒して出力をスキップ。
+	if ( function_exists( 'vgjpm_get_meta_post_types' ) ) {
+		$post_type           = get_post_type();
+		$enabled_post_types  = vgjpm_get_meta_post_types();
+		if ( empty( $post_type ) || ! in_array( $post_type, $enabled_post_types, true ) ) {
+			return;
+		}
+	}
+
 	$post_id       = get_the_ID();
 	$custom_fields = vgjpm_get_custom_fields( $post_id );
-	$json_ld = vgjpm_generate_jsonLD( $custom_fields );
+	$json_ld       = vgjpm_generate_jsonLD( $custom_fields );
 	if ( $json_ld ) {
 		echo wp_kses(
 			$json_ld,
@@ -542,7 +577,15 @@ function vgjpm_esc_newline( $html ) {
  *                     required data (title) is missing.
  ****/
 function vgjpm_generate_jsonLD( $custom_fields ) {
-	if ( ! isset( $custom_fields['vkjp_title'] ) ) {
+	// Treat missing OR empty job title as "no job posting on this page".
+	// Sidebar panel registers post meta via REST and may persist empty
+	// strings, so `isset()` alone is insufficient — we must also reject
+	// blank strings to avoid emitting JSON-LD with no actual content.
+	// 必須項目である求人タイトルが未設定または空文字の場合は
+	// 「このページに求人情報はない」とみなす。サイドバーパネルが
+	// REST 経由で空文字のメタを保存し得るため、isset だけでは不十分で
+	// 空文字も除外する必要がある（中身のない JSON-LD 出力を防ぐ）。
+	if ( empty( $custom_fields['vkjp_title'] ) ) {
 		return;
 	}
 

--- a/vk-google-job-posting-manager.php
+++ b/vk-google-job-posting-manager.php
@@ -485,16 +485,21 @@ function vgjpm_print_jsonLD_in_footer() {
 	}
 
 	// Restrict output to post types that are explicitly enabled for the
-	// job posting metabox / sidebar panel. Falls back gracefully when the
-	// helper is unavailable (older include order, etc.).
+	// job posting metabox / sidebar panel. If the helper is unavailable
+	// (older include order, partial load, etc.) we cannot determine the
+	// allowlist, so we fail safe and skip output rather than risk
+	// emitting JSON-LD on unintended post types.
 	// 求人情報メタボックス/サイドバーパネルが有効な投稿タイプのみで
-	// 出力する。ヘルパー未定義時は安全側に倒して出力をスキップ。
-	if ( function_exists( 'vgjpm_get_meta_post_types' ) ) {
-		$post_type           = get_post_type();
-		$enabled_post_types  = vgjpm_get_meta_post_types();
-		if ( empty( $post_type ) || ! in_array( $post_type, $enabled_post_types, true ) ) {
-			return;
-		}
+	// 出力する。ヘルパー未定義時は許可リストを判定できないため、
+	// 意図しない投稿タイプで JSON-LD が出るのを避けて安全側に倒し、
+	// 出力をスキップする。
+	if ( ! function_exists( 'vgjpm_get_meta_post_types' ) ) {
+		return;
+	}
+	$post_type          = get_post_type();
+	$enabled_post_types = vgjpm_get_meta_post_types();
+	if ( empty( $post_type ) || ! in_array( $post_type, $enabled_post_types, true ) ) {
+		return;
 	}
 
 	$post_id       = get_the_ID();
@@ -577,15 +582,24 @@ function vgjpm_esc_newline( $html ) {
  *                     required data (title) is missing.
  ****/
 function vgjpm_generate_jsonLD( $custom_fields ) {
-	// Treat missing OR empty job title as "no job posting on this page".
+	// Treat missing, empty, or whitespace-only job title as
+	// "no job posting on this page".
 	// Sidebar panel registers post meta via REST and may persist empty
-	// strings, so `isset()` alone is insufficient — we must also reject
-	// blank strings to avoid emitting JSON-LD with no actual content.
-	// 必須項目である求人タイトルが未設定または空文字の場合は
+	// or whitespace-only strings, so `isset()` alone is insufficient —
+	// we must also reject blank strings (including space, tab, full-width
+	// space, etc.) to avoid emitting JSON-LD with no actual content.
+	// 必須項目である求人タイトルが未設定・空文字・空白のみの場合は
 	// 「このページに求人情報はない」とみなす。サイドバーパネルが
-	// REST 経由で空文字のメタを保存し得るため、isset だけでは不十分で
-	// 空文字も除外する必要がある（中身のない JSON-LD 出力を防ぐ）。
-	if ( empty( $custom_fields['vkjp_title'] ) ) {
+	// REST 経由で空文字や空白のみのメタを保存し得るため、isset/empty
+	// だけでは不十分で、半角・全角スペースやタブのみのタイトルも
+	// 除外する必要がある（中身のない JSON-LD 出力を防ぐ）。
+	if ( ! isset( $custom_fields['vkjp_title'] ) ) {
+		return;
+	}
+	$title_raw = is_string( $custom_fields['vkjp_title'] ) ? $custom_fields['vkjp_title'] : '';
+	// Strip Unicode whitespace (handles full-width space U+3000 etc.) before checking.
+	// 全角スペース (U+3000) などの Unicode 空白も含めて判定する。
+	if ( '' === preg_replace( '/^[\s\x{3000}]+|[\s\x{3000}]+$/u', '', $title_raw ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## 概要

求人情報入力欄に何も入力していない投稿でも `<script type="application/ld+json">` の JobPosting 構造化データが出力されてしまい、Google Search Console でエラーが発生する不具合を修正する。

## 原因

1.3.0（PR #110）でブロックエディタのサイドバーパネルに UI を移行した際、`inc/editor-panel.php` で各カスタムフィールドを `register_post_meta()` 経由で REST 登録するようになった。サイドバーパネル（`useEntityProp`）は投稿保存時に**空文字でも meta を永続化**するため、求人情報を一切入力していない投稿でも `vkjp_title` の post meta が空文字（`''`）として保存される。

JSON-LD 生成側の早期 return ガードは `if ( ! isset( $custom_fields['vkjp_title'] ) )` のみだったため、空文字でもキーは存在し `isset` が true となって通過 → 中身のない JobPosting が出力されていた。

## 変更内容

- `vk-google-job-posting-manager.php`
  - `vgjpm_generate_jsonLD()` の早期 return ガードを `! isset()` から `empty()` に変更し、空文字・null も弾くようにした
  - `vgjpm_print_jsonLD_in_footer()` に二重防御として `is_singular()` ガードと対象投稿タイプ（`vgjpm_get_meta_post_types()`）の判定を追加。アーカイブ・トップページや、求人情報メタボックスを有効化していない投稿タイプで JSON+LD が出力されないようにした
- `tests/test-default.php`: 空文字 / キー未指定 / null タイトルで `vgjpm_generate_jsonLD()` が `null` を返すことを検証する PHPUnit テストを 3 件追加
- `readme.txt`: changelog に `[ Bug Fix ]` エントリを追記

## 確認手順

### 前提条件
- WordPress 6.6 以上（ブロックエディタ）
- 本プラグインを有効化
- 「設定 > VK Job Posting Settings」で求人情報投稿タイプ（job-posts）を有効、または任意の公開投稿タイプで「求人情報のカスタムフィールドを表示」を有効化

### 手順

#### Before（修正前の再現手順）
1. 求人情報メタボックスを有効化した投稿タイプで新規投稿を作成
2. タイトルだけ入力し、サイドバーの「Google Job Posting Registration Information」パネルには**何も入力しない**
3. 公開する
4. 公開ページを開きソースを表示
   → ✗ `<script type="application/ld+json">` の中に空の JobPosting データが出力されている
   → ✗ Search Console で「title フィールドがありません」等のエラーが報告される

#### After（修正後の確認手順）
1. 求人情報メタボックスを有効化した投稿タイプで新規投稿を作成
2. タイトルだけ入力し、サイドバーパネルには**何も入力しない**
3. 公開する
4. 公開ページを開きソースを表示
   → ✓ `<script type="application/ld+json">` が出力されていない
5. 同じ投稿を編集し、サイドバーパネルの「Job Title」欄に求人タイトルを入力して更新
6. 公開ページのソースを表示
   → ✓ 従来通り `<script type="application/ld+json">` の JobPosting データが正しく出力される（デグレなし）
7. アーカイブページ（投稿一覧、フロントページ）を表示
   → ✓ JSON-LD が出力されていない
8. 求人情報メタボックスを有効化していない通常の投稿タイプ（例: post）の個別ページを表示
   → ✓ JSON-LD が出力されていない

### PHPUnit
```
npm run phpunit
```
追加した `test_generate_jsonLD_returns_null_when_title_is_empty_string` / `..._is_missing` / `..._is_null` を含め、全テストが pass することを確認してください。

## 関連 issue

closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  - ジョブ投稿情報が不足またはタイトルが空白のみの場合に、空のJSON-LD出力が生成されなくなりました（検索コンソールのエラー抑制）。
* **テスト**
  - 空文字・未設定・null・空白のみのタイトルを含むケースをカバーする単体テストを追加しました。
* **ドキュメント**
  - 変更点を反映した追記（changelog）を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->