### PR TITLE
[ 開発環境 ] Playwright e2e テスト基盤を導入

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,60 @@
+name: E2E Test
+
+# Playwright e2e テスト用ワークフロー。
+# wp-env で WordPress を立ち上げ、本プラグインを有効化した上で
+# tests/e2e/specs 配下のテストを実行する。
+#
+# baseURL は WP_BASE_URL 環境変数で渡す（CI と ローカルでポートが異なる場合に対応）。
+# 既定の wp-env のポート（8889）を使うため、CI では http://localhost:8889 を渡す。
+
+on:
+    push:
+        branches:
+            - master
+            - develop
+    pull_request:
+        branches:
+            - master
+            - develop
+
+jobs:
+    e2e:
+        name: Playwright e2e
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+                  cache: npm
+
+            - name: Install Composer Packages
+              run: composer install --no-interaction --prefer-dist
+
+            - name: Install NPM Packages
+              run: npm install
+
+            - name: Build assets
+              run: npm run build
+
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps chromium
+
+            - name: Start wp-env
+              run: npx wp-env start
+
+            # 既定の wp-env ポート（8889）に対してテストする。
+            # ローカルでは .wp-env.override.json で 9151 を使うため、
+            # ハードコードせず WP_BASE_URL 経由でポートを与える運用にする。
+            - name: Run Playwright tests
+              env:
+                  WP_BASE_URL: http://localhost:8889
+              run: npm run test:e2e
+
+            - name: Upload Playwright report
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ vendor/
 .wp-env.override.json
 .phpunit.result.cache
 .claude/settings.local.json
+
+# Playwright e2e
+/test-results/
+/playwright-report/
+/playwright/.cache/
+/blob-report/

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # vk-google-job-posting-manager
 
 ビルド
-```
+```bash
 npm run build
 ```
 
 PHPUnitテスト
-```
+```bash
 npm run phpunit
 ```
 
 Playwright e2e テスト
-```
+```bash
 # 初回のみ: ブラウザのインストール
 npm run test:e2e:install
 
@@ -22,4 +22,3 @@ npm run test:e2e
 # CI 等でポートを変えたい場合は WP_BASE_URL を指定
 WP_BASE_URL=http://localhost:8889 npm run test:e2e
 ```
-

--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@ PHPUnitテスト
 npm run phpunit
 ```
 
+Playwright e2e テスト
+```
+# 初回のみ: ブラウザのインストール
+npm run test:e2e:install
+
+# wp-env を起動した状態で実行（.wp-env.override.json では 9151 ポートを使用）
+npx wp-env start
+npm run test:e2e
+
+# CI 等でポートを変えたい場合は WP_BASE_URL を指定
+WP_BASE_URL=http://localhost:8889 npm run test:e2e
+```
+

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "dist": "composer install --optimize-autoloader --prefer-dist --no-dev && npm run build && bash bin/dist.sh && composer install",
     "gulp": "npx gulp",
     "phpunit": "composer install && npx wp-env run tests-cli --env-cwd='wp-content/plugins/vk-google-job-posting-manager' vendor/bin/phpunit -c .phpunit.xml --verbose",
-    "test": "bash bin/install-wp-tests.sh wordpress_test root 'wordpress' localhost latest && phpunit"
+    "test": "bash bin/install-wp-tests.sh wordpress_test root 'wordpress' localhost latest && phpunit",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:install": "playwright install --with-deps chromium"
   },
   "browserslist": [
     "last 2 version",
@@ -24,7 +27,9 @@
   ],
   "devDependencies": {
     "@emotion/babel-plugin": "^11.12.0",
+    "@playwright/test": "^1.48.0",
     "@wordpress/babel-plugin-makepot": "^6.7.0",
+    "@wordpress/e2e-test-utils-playwright": "^1.20.0",
     "@wordpress/env": "^10.33.0",
     "@wordpress/i18n": "^5.7.0",
     "@wordpress/scripts": "^31.6.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,65 @@
+/**
+ * Playwright 設定ファイル
+ *
+ * - baseURL は WP_BASE_URL 環境変数で上書き可能。
+ *   ローカルでは .wp-env.override.json で 9151 ポートを指定しているため、
+ *   デフォルトを http://localhost:9151 とする。
+ *   CI 環境では GitHub Actions 側で WP_BASE_URL を渡すことを想定する。
+ * - テストファイル内で page.goto() に絶対 URL をハードコードしないこと
+ *   （rules/testing/e2e.md のルール）。
+ *
+ * @see https://playwright.dev/docs/test-configuration
+ */
+
+const { defineConfig, devices } = require( '@playwright/test' );
+
+module.exports = defineConfig( {
+	// e2e テストの配置先 / Where e2e specs live.
+	testDir: './tests/e2e/specs',
+
+	// 1 ファイル内のテストを順次実行（投稿作成→公開ページ確認のような
+	// 状態を引き継ぐシナリオがあるため、parallel ではなく serial にする）。
+	fullyParallel: false,
+
+	// CI 上で .only を残したテストがあれば失敗させる。
+	forbidOnly: !! process.env.CI,
+
+	// CI ではフレーク対策で 2 回までリトライする。
+	retries: process.env.CI ? 2 : 0,
+
+	// ローカルは並列度 1。WordPress のグローバル状態（投稿・オプション）を
+	// 共有しているため、ワーカーを増やすと相互干渉する。
+	workers: 1,
+
+	// Reporter / レポーター
+	reporter: process.env.CI ? [ [ 'github' ], [ 'html', { open: 'never' } ] ] : 'list',
+
+	// 各テスト共通の設定 / Shared test settings.
+	use: {
+		// ベース URL は環境変数で切替可能にする（CI とローカルでポートが異なるため）。
+		baseURL: process.env.WP_BASE_URL || 'http://localhost:9151',
+
+		// 失敗時のみトレース / Trace only on first retry to keep CI fast.
+		trace: 'retain-on-failure',
+
+		// 失敗時のみスクリーンショット / Screenshot only on failure.
+		screenshot: 'only-on-failure',
+
+		// HTTPS 証明書検証は無効（wp-env はオレオレ証明書になり得るため）。
+		ignoreHTTPSErrors: true,
+	},
+
+	// 個別テストのタイムアウト（WordPress エディタの起動が遅いことがあるため少し長め）。
+	timeout: 60 * 1000,
+	expect: {
+		timeout: 10 * 1000,
+	},
+
+	// 対象ブラウザ / Target browsers.
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+	],
+} );

--- a/tests/e2e/specs/json-ld-output.spec.js
+++ b/tests/e2e/specs/json-ld-output.spec.js
@@ -5,22 +5,22 @@
  * 出力され Search Console エラーが起きる）に対する回帰テスト。
  *
  * 観点:
- *  1. 求人情報サイドバー未入力で公開した投稿で <script type="application/ld+json">
- *     が出力されないこと
- *  2. 求人情報を入力して公開した投稿で従来通り JSON-LD が出力されること
- *  3. アーカイブページ・対象外投稿タイプで JSON-LD が出ないこと
+ *  1. 求人情報サイドバー未入力で公開した投稿で JobPosting JSON-LD が
+ *     出力されないこと
+ *  2. 求人情報を入力して公開した投稿で従来通り JobPosting JSON-LD が
+ *     出力されること
+ *  3. アーカイブページ・対象外投稿タイプで JobPosting JSON-LD が出ないこと
  *
  * 実装メモ:
  *  - 投稿作成・meta 設定・クリーンアップは wp-cli 経由で行う。
  *    ブロックエディタ UI を経由した REST 保存は手順が長く、
  *    JSON-LD 出力（フロント側 wp_head）の検証目的では不要なため。
- *  - JSON-LD の有無判定はフロントの HTML を取得し
- *    `<script type="application/ld+json">` 文字列の有無でチェックする。
+ *  - JSON-LD の有無判定は HTML 中に `application/ld+json` の <script> が
+ *    あるかどうかではなく、`"@type":"JobPosting"` を含むかどうかで判定する。
+ *    テーマや他プラグインが別の schema.org JSON-LD（BreadcrumbList 等）を
+ *    出力していても誤検知しないようにするため。
  *
- * 前提: PR #124 の修正がマージ済みであること。本ブランチは master ベースのため、
- *      PR #124 がマージされる前にこの spec を流すと「未入力ケースで JSON-LD
- *      が出力される」=> JSON-LD 抑止テストが FAIL する想定。
- *      PR #124 マージ後にリベースすれば全テスト PASS する。
+ * 前提: PR #124 の修正がマージ済みであること（master ベース）。
  */
 
 const { test, expect } = require( '@playwright/test' );
@@ -43,14 +43,30 @@ async function fetchHtml( request, url ) {
 }
 
 /**
- * HTML 内に JobPosting JSON-LD（<script type="application/ld+json">）が
- * 含まれているかを返す。
+ * HTML 内に JobPosting タイプの JSON-LD が含まれているかを返す。
+ *
+ * `application/ld+json` だけで判定するとテーマや他プラグインが出力する
+ * BreadcrumbList / Article などの schema.org JSON-LD で誤検知してしまう。
+ * そこで `<script type="application/ld+json">` ブロックの中に
+ * `"@type":"JobPosting"` が含まれることまで確認する。
  *
  * @param {string} html
  * @returns {boolean}
  */
-function hasJsonLd( html ) {
-	return /<script\s+type=["']application\/ld\+json["']/i.test( html );
+function hasJobPostingJsonLd( html ) {
+	return /<script\s+type=["']application\/ld\+json["'][^>]*>[\s\S]*?"@type"\s*:\s*"JobPosting"/i.test( html );
+}
+
+/**
+ * `<script type="application/ld+json">...</script>` の最初のブロックの
+ * 中身（JSON 文字列）を返す。見つからない場合は null。
+ *
+ * @param {string} html
+ * @returns {string|null}
+ */
+function extractFirstJsonLd( html ) {
+	const match = html.match( /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i );
+	return match ? match[ 1 ].trim() : null;
 }
 
 test.describe( 'JSON-LD 出力（issue #123 / PR #124 回帰テスト）', () => {
@@ -67,117 +83,137 @@ test.describe( 'JSON-LD 出力（issue #123 / PR #124 回帰テスト）', () =>
 		createdPostIds = [];
 	} );
 
-	test( '未入力で公開した job-posts では JSON-LD が出力されない', async ( { request } ) => {
+	test( '未入力で公開した job-posts では JobPosting JSON-LD が出力されない', async ( { request } ) => {
 		// 求人情報を一切入力せず、タイトルのみで job-posts を公開する。
 		// 修正前は post meta `vkjp_title` がサイドバーパネル経由で空文字保存され、
 		// `isset()` ガードを通過してしまうため空の JobPosting が出力されていた。
-		const postId = wpCli(
-			"post create --post_type=job-posts --post_status=publish --post_title='E2E: empty job posting' --porcelain"
-		);
+		const postId = wpCli( [
+			'post', 'create',
+			'--post_type=job-posts',
+			'--post_status=publish',
+			'--post_title=E2E: empty job posting',
+			'--porcelain',
+		] );
 		expect( postId ).toMatch( /^\d+$/ );
 		createdPostIds.push( postId );
 
 		// 修正のシミュレーション: 空文字 meta を REST 経由保存と同じように差し込む。
-		// （wp-cli から meta を空文字で update する）
-		wpCli( `post meta update ${ postId } vkjp_title ''` );
+		wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_title', '' ] );
 
-		// フロントの HTML を取得し JSON-LD が無いことを確認する。
-		const url = wpCli( `post url ${ postId }` );
+		// フロントの HTML を取得し JobPosting JSON-LD が無いことを確認する。
+		const url = wpCli( [ 'post', 'url', postId ] );
 		const html = await fetchHtml( request, url );
 
 		expect(
-			hasJsonLd( html ),
-			'未入力の求人情報投稿で JSON-LD が出力されてはいけない（issue #123）'
+			hasJobPostingJsonLd( html ),
+			'未入力の求人情報投稿で JobPosting JSON-LD が出力されてはいけない（issue #123）'
 		).toBe( false );
 	} );
 
-	test( '空白のみのタイトルで公開した job-posts では JSON-LD が出力されない', async ( { request } ) => {
+	test( '空白のみのタイトルで公開した job-posts では JobPosting JSON-LD が出力されない', async ( { request } ) => {
 		// 半角スペース / タブ / 全角スペースのみのタイトルも「未入力」扱いとする
 		// （PR #124 の f4b3711 で対応された強化分）。
-		const postId = wpCli(
-			"post create --post_type=job-posts --post_status=publish --post_title='E2E: whitespace job title' --porcelain"
-		);
+		const postId = wpCli( [
+			'post', 'create',
+			'--post_type=job-posts',
+			'--post_status=publish',
+			'--post_title=E2E: whitespace job title',
+			'--porcelain',
+		] );
 		createdPostIds.push( postId );
 
-		// 半角スペース + タブ + 全角スペース。
-		wpCli( `post meta update ${ postId } vkjp_title ' \t　'` );
+		// 半角スペース + タブ + 全角スペース。spawnSync の引数配列で渡すため
+		// シェルエスケープを気にせず生の文字列を渡せる。
+		wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_title', ' \t　' ] );
 
-		const url = wpCli( `post url ${ postId }` );
+		const url = wpCli( [ 'post', 'url', postId ] );
 		const html = await fetchHtml( request, url );
 
 		expect(
-			hasJsonLd( html ),
-			'空白文字のみのタイトルでも JSON-LD は出力されてはいけない'
+			hasJobPostingJsonLd( html ),
+			'空白文字のみのタイトルでも JobPosting JSON-LD は出力されてはいけない'
 		).toBe( false );
 	} );
 
-	test( '求人情報を入力した job-posts では JSON-LD が従来通り出力される', async ( { request } ) => {
+	test( '求人情報を入力した job-posts では JobPosting JSON-LD が従来通り出力される', async ( { request } ) => {
 		// 必須項目（title）と最低限の補助項目を入力した投稿を作成し、
 		// 従来通り JobPosting JSON-LD が出力されることを確認する（デグレチェック）。
-		const postId = wpCli(
-			"post create --post_type=job-posts --post_status=publish --post_title='E2E: filled job posting' --post_content='Test job description' --porcelain"
-		);
+		const postId = wpCli( [
+			'post', 'create',
+			'--post_type=job-posts',
+			'--post_status=publish',
+			'--post_title=E2E: filled job posting',
+			'--post_content=Test job description',
+			'--porcelain',
+		] );
 		createdPostIds.push( postId );
 
 		// 求人情報フィールドを wp-cli で投入。
-		wpCli( `post meta update ${ postId } vkjp_title 'Senior WordPress Engineer'` );
-		wpCli( `post meta update ${ postId } vkjp_description 'We are hiring!'` );
-		wpCli( `post meta update ${ postId } vkjp_datePosted '2026-04-01'` );
-		wpCli( `post meta update ${ postId } vkjp_validThrough '2026-12-31'` );
-		wpCli( `post meta update ${ postId } vkjp_name 'Vektor, Inc.'` );
+		wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_title', 'Senior WordPress Engineer' ] );
+		wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_description', 'We are hiring!' ] );
+		wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_datePosted', '2026-04-01' ] );
+		wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_validThrough', '2026-12-31' ] );
+		wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_name', 'Vektor, Inc.' ] );
 
-		const url = wpCli( `post url ${ postId }` );
+		const url = wpCli( [ 'post', 'url', postId ] );
 		const html = await fetchHtml( request, url );
 
 		expect(
-			hasJsonLd( html ),
-			'求人情報を入力済みの job-posts では JSON-LD が出力されるはず（デグレ防止）'
+			hasJobPostingJsonLd( html ),
+			'求人情報を入力済みの job-posts では JobPosting JSON-LD が出力されるはず（デグレ防止）'
 		).toBe( true );
 
-		// 中身も簡易チェック: JobPosting タイプと title 文字列を含むこと。
-		const match = html.match( /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i );
-		expect( match, 'application/ld+json の <script> ブロックが取得できること' ).not.toBeNull();
-		const jsonText = match[ 1 ].trim();
+		// 中身も簡易チェック: title 文字列を含むこと。
+		const jsonText = extractFirstJsonLd( html );
+		expect( jsonText, 'application/ld+json の <script> ブロックが取得できること' ).not.toBeNull();
 		expect( jsonText ).toContain( 'JobPosting' );
 		expect( jsonText ).toContain( 'Senior WordPress Engineer' );
 	} );
 
-	test( 'アーカイブページでは JSON-LD が出力されない', async ( { request } ) => {
+	test( 'アーカイブページでは JobPosting JSON-LD が出力されない', async ( { request } ) => {
 		// アーカイブ（投稿一覧）には JobPosting JSON-LD が出るべきではない。
 		// 入力済みの job-posts を 1 件作成してから、その投稿タイプアーカイブを開く。
-		const postId = wpCli(
-			"post create --post_type=job-posts --post_status=publish --post_title='E2E: archive check posting' --porcelain"
-		);
+		const postId = wpCli( [
+			'post', 'create',
+			'--post_type=job-posts',
+			'--post_status=publish',
+			'--post_title=E2E: archive check posting',
+			'--porcelain',
+		] );
 		createdPostIds.push( postId );
-		wpCli( `post meta update ${ postId } vkjp_title 'Archive Check Title'` );
+		wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_title', 'Archive Check Title' ] );
 
 		// job-posts のアーカイブ（パーマリンク設定によっては /?post_type=job-posts でアクセス可）。
 		const html = await fetchHtml( request, '/?post_type=job-posts' );
 
 		expect(
-			hasJsonLd( html ),
-			'アーカイブページに JSON-LD が出力されてはいけない'
+			hasJobPostingJsonLd( html ),
+			'アーカイブページに JobPosting JSON-LD が出力されてはいけない'
 		).toBe( false );
 	} );
 
-	test( '対象外投稿タイプ（page）の個別ページでは JSON-LD が出力されない', async ( { request } ) => {
+	test( '対象外投稿タイプ（page）の個別ページでは JobPosting JSON-LD が出力されない', async ( { request } ) => {
 		// 求人情報メタボックスを有効化していない page 投稿タイプでは、
 		// たとえ何らかの経路で vkjp_title meta が付いても JSON-LD は出してはいけない。
-		const pageId = wpCli(
-			"post create --post_type=page --post_status=publish --post_title='E2E: out-of-scope page' --porcelain"
-		);
+		const pageId = wpCli( [
+			'post', 'create',
+			'--post_type=page',
+			'--post_status=publish',
+			'--post_title=E2E: out-of-scope page',
+			'--porcelain',
+		] );
 		createdPostIds.push( pageId );
 
 		// page でも誤って vkjp_title meta が入った状況をシミュレートする
 		// （`vgjpm_print_jsonLD_in_footer` の post type ガードがあるため出力されないはず）。
-		wpCli( `post meta update ${ pageId } vkjp_title 'Should not output JSON-LD'` );
+		wpCli( [ 'post', 'meta', 'update', pageId, 'vkjp_title', 'Should not output JSON-LD' ] );
 
-		const url = wpCli( `post url ${ pageId }` );
+		const url = wpCli( [ 'post', 'url', pageId ] );
 		const html = await fetchHtml( request, url );
 
 		expect(
-			hasJsonLd( html ),
-			'対象外の投稿タイプ（page）で JSON-LD が出力されてはいけない'
+			hasJobPostingJsonLd( html ),
+			'対象外の投稿タイプ（page）で JobPosting JSON-LD が出力されてはいけない'
 		).toBe( false );
 	} );
 } );

--- a/tests/e2e/specs/json-ld-output.spec.js
+++ b/tests/e2e/specs/json-ld-output.spec.js
@@ -1,0 +1,183 @@
+/**
+ * JSON-LD 出力に関する e2e テスト
+ *
+ * issue #123 / PR #124 の不具合（求人情報未入力でも空の JobPosting 構造化データが
+ * 出力され Search Console エラーが起きる）に対する回帰テスト。
+ *
+ * 観点:
+ *  1. 求人情報サイドバー未入力で公開した投稿で <script type="application/ld+json">
+ *     が出力されないこと
+ *  2. 求人情報を入力して公開した投稿で従来通り JSON-LD が出力されること
+ *  3. アーカイブページ・対象外投稿タイプで JSON-LD が出ないこと
+ *
+ * 実装メモ:
+ *  - 投稿作成・meta 設定・クリーンアップは wp-cli 経由で行う。
+ *    ブロックエディタ UI を経由した REST 保存は手順が長く、
+ *    JSON-LD 出力（フロント側 wp_head）の検証目的では不要なため。
+ *  - JSON-LD の有無判定はフロントの HTML を取得し
+ *    `<script type="application/ld+json">` 文字列の有無でチェックする。
+ *
+ * 前提: PR #124 の修正がマージ済みであること。本ブランチは master ベースのため、
+ *      PR #124 がマージされる前にこの spec を流すと「未入力ケースで JSON-LD
+ *      が出力される」=> JSON-LD 抑止テストが FAIL する想定。
+ *      PR #124 マージ後にリベースすれば全テスト PASS する。
+ */
+
+const { test, expect } = require( '@playwright/test' );
+const { wpCli, ensureJobPostsEnabled, deletePost } = require( '../utils/wp-cli' );
+
+// 各テストで作成した投稿 ID を集めておき、afterEach で一括削除する。
+let createdPostIds = [];
+
+/**
+ * 指定 URL のフロント HTML を fetch して返す（Playwright の page.request を使用）。
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string}                                       url     相対パスでも絶対パスでも可
+ * @returns {Promise<string>}
+ */
+async function fetchHtml( request, url ) {
+	const response = await request.get( url );
+	expect( response.ok(), `フロント取得失敗: ${ url } (status=${ response.status() })` ).toBeTruthy();
+	return await response.text();
+}
+
+/**
+ * HTML 内に JobPosting JSON-LD（<script type="application/ld+json">）が
+ * 含まれているかを返す。
+ *
+ * @param {string} html
+ * @returns {boolean}
+ */
+function hasJsonLd( html ) {
+	return /<script\s+type=["']application\/ld\+json["']/i.test( html );
+}
+
+test.describe( 'JSON-LD 出力（issue #123 / PR #124 回帰テスト）', () => {
+	test.beforeAll( () => {
+		// テストの独立性確保のため、求人情報 CPT を有効化しておく。
+		ensureJobPostsEnabled();
+	} );
+
+	test.afterEach( () => {
+		// テストで作成した投稿を全削除（DB に残骸を残さない）。
+		for ( const id of createdPostIds ) {
+			deletePost( id );
+		}
+		createdPostIds = [];
+	} );
+
+	test( '未入力で公開した job-posts では JSON-LD が出力されない', async ( { request } ) => {
+		// 求人情報を一切入力せず、タイトルのみで job-posts を公開する。
+		// 修正前は post meta `vkjp_title` がサイドバーパネル経由で空文字保存され、
+		// `isset()` ガードを通過してしまうため空の JobPosting が出力されていた。
+		const postId = wpCli(
+			"post create --post_type=job-posts --post_status=publish --post_title='E2E: empty job posting' --porcelain"
+		);
+		expect( postId ).toMatch( /^\d+$/ );
+		createdPostIds.push( postId );
+
+		// 修正のシミュレーション: 空文字 meta を REST 経由保存と同じように差し込む。
+		// （wp-cli から meta を空文字で update する）
+		wpCli( `post meta update ${ postId } vkjp_title ''` );
+
+		// フロントの HTML を取得し JSON-LD が無いことを確認する。
+		const url = wpCli( `post url ${ postId }` );
+		const html = await fetchHtml( request, url );
+
+		expect(
+			hasJsonLd( html ),
+			'未入力の求人情報投稿で JSON-LD が出力されてはいけない（issue #123）'
+		).toBe( false );
+	} );
+
+	test( '空白のみのタイトルで公開した job-posts では JSON-LD が出力されない', async ( { request } ) => {
+		// 半角スペース / タブ / 全角スペースのみのタイトルも「未入力」扱いとする
+		// （PR #124 の f4b3711 で対応された強化分）。
+		const postId = wpCli(
+			"post create --post_type=job-posts --post_status=publish --post_title='E2E: whitespace job title' --porcelain"
+		);
+		createdPostIds.push( postId );
+
+		// 半角スペース + タブ + 全角スペース。
+		wpCli( `post meta update ${ postId } vkjp_title ' \t　'` );
+
+		const url = wpCli( `post url ${ postId }` );
+		const html = await fetchHtml( request, url );
+
+		expect(
+			hasJsonLd( html ),
+			'空白文字のみのタイトルでも JSON-LD は出力されてはいけない'
+		).toBe( false );
+	} );
+
+	test( '求人情報を入力した job-posts では JSON-LD が従来通り出力される', async ( { request } ) => {
+		// 必須項目（title）と最低限の補助項目を入力した投稿を作成し、
+		// 従来通り JobPosting JSON-LD が出力されることを確認する（デグレチェック）。
+		const postId = wpCli(
+			"post create --post_type=job-posts --post_status=publish --post_title='E2E: filled job posting' --post_content='Test job description' --porcelain"
+		);
+		createdPostIds.push( postId );
+
+		// 求人情報フィールドを wp-cli で投入。
+		wpCli( `post meta update ${ postId } vkjp_title 'Senior WordPress Engineer'` );
+		wpCli( `post meta update ${ postId } vkjp_description 'We are hiring!'` );
+		wpCli( `post meta update ${ postId } vkjp_datePosted '2026-04-01'` );
+		wpCli( `post meta update ${ postId } vkjp_validThrough '2026-12-31'` );
+		wpCli( `post meta update ${ postId } vkjp_name 'Vektor, Inc.'` );
+
+		const url = wpCli( `post url ${ postId }` );
+		const html = await fetchHtml( request, url );
+
+		expect(
+			hasJsonLd( html ),
+			'求人情報を入力済みの job-posts では JSON-LD が出力されるはず（デグレ防止）'
+		).toBe( true );
+
+		// 中身も簡易チェック: JobPosting タイプと title 文字列を含むこと。
+		const match = html.match( /<script\s+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i );
+		expect( match, 'application/ld+json の <script> ブロックが取得できること' ).not.toBeNull();
+		const jsonText = match[ 1 ].trim();
+		expect( jsonText ).toContain( 'JobPosting' );
+		expect( jsonText ).toContain( 'Senior WordPress Engineer' );
+	} );
+
+	test( 'アーカイブページでは JSON-LD が出力されない', async ( { request } ) => {
+		// アーカイブ（投稿一覧）には JobPosting JSON-LD が出るべきではない。
+		// 入力済みの job-posts を 1 件作成してから、その投稿タイプアーカイブを開く。
+		const postId = wpCli(
+			"post create --post_type=job-posts --post_status=publish --post_title='E2E: archive check posting' --porcelain"
+		);
+		createdPostIds.push( postId );
+		wpCli( `post meta update ${ postId } vkjp_title 'Archive Check Title'` );
+
+		// job-posts のアーカイブ（パーマリンク設定によっては /?post_type=job-posts でアクセス可）。
+		const html = await fetchHtml( request, '/?post_type=job-posts' );
+
+		expect(
+			hasJsonLd( html ),
+			'アーカイブページに JSON-LD が出力されてはいけない'
+		).toBe( false );
+	} );
+
+	test( '対象外投稿タイプ（page）の個別ページでは JSON-LD が出力されない', async ( { request } ) => {
+		// 求人情報メタボックスを有効化していない page 投稿タイプでは、
+		// たとえ何らかの経路で vkjp_title meta が付いても JSON-LD は出してはいけない。
+		const pageId = wpCli(
+			"post create --post_type=page --post_status=publish --post_title='E2E: out-of-scope page' --porcelain"
+		);
+		createdPostIds.push( pageId );
+
+		// page でも誤って vkjp_title meta が入った状況をシミュレートする
+		// （`vgjpm_print_jsonLD_in_footer` の post type ガードがあるため出力されないはず）。
+		wpCli( `post meta update ${ pageId } vkjp_title 'Should not output JSON-LD'` );
+
+		const url = wpCli( `post url ${ pageId }` );
+		const html = await fetchHtml( request, url );
+
+		expect(
+			hasJsonLd( html ),
+			'対象外の投稿タイプ（page）で JSON-LD が出力されてはいけない'
+		).toBe( false );
+	} );
+} );

--- a/tests/e2e/utils/auth.js
+++ b/tests/e2e/utils/auth.js
@@ -1,0 +1,36 @@
+/**
+ * 管理者ログイン用の共通ユーティリティ。
+ *
+ * @wordpress/e2e-test-utils-playwright を使えば admin fixture が利用できるが、
+ * 設定や依存の都合で pure Playwright のみで動かす場面もあるため、
+ * フォールバック用としてこのヘルパーを用意する。
+ */
+
+/**
+ * wp-login.php 経由で admin ログインする。
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {Object}                          [options]
+ * @param {string}                          [options.username='admin']
+ * @param {string}                          [options.password='password']
+ */
+async function loginAsAdmin( page, options = {} ) {
+	const username = options.username || 'admin';
+	const password = options.password || 'password';
+
+	await page.goto( '/wp-login.php' );
+
+	// ログイン済みなら wp-admin にリダイレクトされるためスキップ。
+	if ( page.url().includes( '/wp-admin' ) ) {
+		return;
+	}
+
+	await page.fill( '#user_login', username );
+	await page.fill( '#user_pass', password );
+	await page.click( '#wp-submit' );
+
+	// ダッシュボードまたはサイトの管理画面が表示されるまで待つ。
+	await page.waitForURL( /\/wp-admin\/?/, { timeout: 15000 } );
+}
+
+module.exports = { loginAsAdmin };

--- a/tests/e2e/utils/wp-cli.js
+++ b/tests/e2e/utils/wp-cli.js
@@ -1,0 +1,50 @@
+/**
+ * wp-env 経由で wp-cli コマンドを実行するユーティリティ。
+ *
+ * Playwright のテスト中で投稿作成・オプション操作・クリーンアップを
+ * 手早く行いたい場合に使う。`npx wp-env run cli wp ...` を子プロセスで実行する。
+ */
+
+const { execSync } = require( 'child_process' );
+const path = require( 'path' );
+
+// プラグインルートを基準に wp-env を呼ぶ（package.json と .wp-env.json がある場所）。
+const PLUGIN_ROOT = path.resolve( __dirname, '../../..' );
+
+/**
+ * wp-cli コマンドを実行して標準出力を返す。
+ *
+ * @param {string} command wp の後ろに続く部分（例: "post create --post_title=foo"）
+ * @returns {string} stdout の文字列。
+ */
+function wpCli( command ) {
+	const full = `npx wp-env run cli wp ${ command }`;
+	return execSync( full, {
+		cwd: PLUGIN_ROOT,
+		encoding: 'utf8',
+		stdio: [ 'ignore', 'pipe', 'pipe' ],
+	} ).trim();
+}
+
+/**
+ * 求人情報投稿タイプ（job-posts）が有効になっていることを保証する。
+ * デフォルト有効だが、テスト独立性のため明示的に on にしておく。
+ */
+function ensureJobPostsEnabled() {
+	wpCli( "option update vgjpm_create_jobpost_posttype 'true'" );
+}
+
+/**
+ * 投稿を ID 指定で削除する（trash ではなく force delete）。
+ *
+ * @param {number|string} postId
+ */
+function deletePost( postId ) {
+	try {
+		wpCli( `post delete ${ postId } --force` );
+	} catch ( _e ) {
+		// 既に削除済みの場合などは無視する。
+	}
+}
+
+module.exports = { wpCli, ensureJobPostsEnabled, deletePost };

--- a/tests/e2e/utils/wp-cli.js
+++ b/tests/e2e/utils/wp-cli.js
@@ -3,9 +3,14 @@
  *
  * Playwright のテスト中で投稿作成・オプション操作・クリーンアップを
  * 手早く行いたい場合に使う。`npx wp-env run cli wp ...` を子プロセスで実行する。
+ *
+ * 実装メモ:
+ *  - 文字列連結 + execSync は引用符・空白・特殊文字でシェルが壊れる可能性が
+ *    あるため、引数配列ベースの spawnSync を使用する。
+ *  - 失敗時は stderr を含めた Error を throw する。
  */
 
-const { execSync } = require( 'child_process' );
+const { spawnSync } = require( 'child_process' );
 const path = require( 'path' );
 
 // プラグインルートを基準に wp-env を呼ぶ（package.json と .wp-env.json がある場所）。
@@ -14,16 +19,51 @@ const PLUGIN_ROOT = path.resolve( __dirname, '../../..' );
 /**
  * wp-cli コマンドを実行して標準出力を返す。
  *
- * @param {string} command wp の後ろに続く部分（例: "post create --post_title=foo"）
- * @returns {string} stdout の文字列。
+ * 使用例:
+ *   wpCli( [ 'post', 'create', '--post_type=job-posts', '--post_status=publish', '--porcelain' ] );
+ *   wpCli( [ 'post', 'meta', 'update', postId, 'vkjp_title', 'Some title' ] );
+ *
+ * 引数は配列で渡すこと。シェルを介さないため、空白や引用符を含む値も
+ * そのまま渡せる（個別引数として安全に扱われる）。
+ *
+ * @param {string[]} args wp の後ろに続く引数の配列。
+ * @returns {string} stdout の文字列（trim 済み）。
+ * @throws  {Error}  終了コードが 0 以外、またはプロセス起動に失敗した場合。
  */
-function wpCli( command ) {
-	const full = `npx wp-env run cli wp ${ command }`;
-	return execSync( full, {
-		cwd: PLUGIN_ROOT,
-		encoding: 'utf8',
-		stdio: [ 'ignore', 'pipe', 'pipe' ],
-	} ).trim();
+function wpCli( args ) {
+	if ( ! Array.isArray( args ) ) {
+		throw new TypeError( 'wpCli() requires an array of arguments.' );
+	}
+
+	// `npx wp-env run cli wp <args...>` を引数配列で起動する。
+	// shell: false（既定）にすることで、引数ごとの境界が保たれる。
+	const result = spawnSync(
+		'npx',
+		[ 'wp-env', 'run', 'cli', 'wp', ...args ],
+		{
+			cwd: PLUGIN_ROOT,
+			encoding: 'utf8',
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+		}
+	);
+
+	// プロセス自体の起動に失敗した場合（npx 不在等）。
+	if ( result.error ) {
+		throw new Error(
+			`Failed to spawn wp-cli (wp ${ args.join( ' ' ) }): ${ result.error.message }`
+		);
+	}
+
+	if ( result.status !== 0 ) {
+		const stderr = ( result.stderr || '' ).trim();
+		const stdout = ( result.stdout || '' ).trim();
+		throw new Error(
+			`wp-cli exited with status ${ result.status } (wp ${ args.join( ' ' ) }):\n` +
+				`stderr: ${ stderr }\nstdout: ${ stdout }`
+		);
+	}
+
+	return ( result.stdout || '' ).trim();
 }
 
 /**
@@ -31,19 +71,36 @@ function wpCli( command ) {
  * デフォルト有効だが、テスト独立性のため明示的に on にしておく。
  */
 function ensureJobPostsEnabled() {
-	wpCli( "option update vgjpm_create_jobpost_posttype 'true'" );
+	wpCli( [ 'option', 'update', 'vgjpm_create_jobpost_posttype', 'true' ] );
 }
 
 /**
  * 投稿を ID 指定で削除する（trash ではなく force delete）。
  *
+ * 「投稿が既に存在しない」エラーは afterEach のクリーンアップで頻繁に
+ * 発生するため握りつぶすが、それ以外（wp-env 障害・コマンド誤り等）は
+ * 黙って通すと不具合の見落としに繋がるので再 throw する。
+ *
  * @param {number|string} postId
+ * @throws {Error} 「存在しない」以外の wp-cli エラーが発生した場合。
  */
 function deletePost( postId ) {
 	try {
-		wpCli( `post delete ${ postId } --force` );
-	} catch ( _e ) {
-		// 既に削除済みの場合などは無視する。
+		wpCli( [ 'post', 'delete', String( postId ), '--force' ] );
+	} catch ( err ) {
+		// wp-cli は対象が無いとき "Error: Could not find the post with ID xxx."
+		// "post does not exist" などのメッセージを返す。
+		// メッセージからこれらのマーカーを検出した場合のみ無視する。
+		const message = ( err && err.message ) ? err.message.toLowerCase() : '';
+		const isMissing =
+			message.includes( 'could not find the post' ) ||
+			message.includes( 'does not exist' ) ||
+			message.includes( 'not found' ) ||
+			message.includes( 'invalid post id' );
+
+		if ( ! isMissing ) {
+			throw err;
+		}
 	}
 }
 


### PR DESCRIPTION
## 概要

本リポジトリに Playwright e2e テスト基盤を新規導入し、あわせて issue #123 / PR #124 の修正に対する回帰テストを追加する。

## 背景

- issue #123（求人情報未入力でも空の JSON-LD が出力される不具合）は、ブロックエディタのサイドバーパネル経由で post meta が空文字保存されることに起因する。
- このタイプの不具合は **実際に投稿を保存してフロント HTML を確認しないと再現できない** ため、PHPUnit だけでは回帰検知が難しい。
- そこで Playwright + wp-env による e2e 基盤を整備し、フロント HTML 上での JSON-LD 出力有無を検証できるようにした。

## 変更内容

### Playwright 基盤
- `@playwright/test` と `@wordpress/e2e-test-utils-playwright` を devDependency に追加
- `playwright.config.js` を追加
  - `baseURL` は `WP_BASE_URL` 環境変数で切替可能（CI とローカルでポートが異なる前提）
  - ローカル既定は `http://localhost:9151`（`.wp-env.override.json` のポート）
  - 失敗時のみ trace / screenshot を保存
- `tests/e2e/` ディレクトリを新規作成
  - `tests/e2e/utils/wp-cli.js`: wp-env 経由で wp-cli を呼ぶヘルパー
  - `tests/e2e/utils/auth.js`: admin ログインヘルパー
  - `tests/e2e/specs/json-ld-output.spec.js`: JSON-LD 回帰テスト本体
- `package.json` に `test:e2e` / `test:e2e:ui` / `test:e2e:install` スクリプトを追加
- `.github/workflows/e2e_test.yml` を追加（push / PR で自動実行）
- `README.md` に e2e 起動手順を追記
- `.gitignore` に Playwright 成果物（`test-results/`, `playwright-report/` 等）を追加

### e2e テスト（issue #123 回帰）
`tests/e2e/specs/json-ld-output.spec.js` で以下をカバー:

| # | テストシナリオ | 期待結果 |
|---|---------------|----------|
| 1 | 未入力（vkjp_title 空文字）で公開した job-posts | `<script type=\"application/ld+json\">` が出力されない |
| 2 | 空白のみのタイトルで公開した job-posts | 同上（PR #124 f4b3711 の強化分） |
| 3 | 求人情報を入力した job-posts | JSON-LD が JobPosting タイプで出力される（デグレ防止） |
| 4 | アーカイブページ（`?post_type=job-posts`） | JSON-LD が出力されない |
| 5 | 対象外投稿タイプ（page）の個別ページ | JSON-LD が出力されない |

## ブランチ運用について

本 PR は **master ベース** で切ったため、PR #124 の修正コミットを含まない。そのため:

- **PR #124 マージ前** に本 PR の e2e を流すと、テスト #1 / #2（未入力で JSON-LD が出ないこと）が **FAIL する想定**（master の現状は不具合修正前）。
- **PR #124 マージ後** に本ブランチを master にリベースすれば全テスト PASS する。

→ レビュー順としては「PR #124 を先にマージ → 本 PR をリベース → e2e CI が通ることを確認 → 本 PR をマージ」を推奨。

## 動作確認手順（ローカル）

```bash
# 依存インストール
npm install
npx playwright install --with-deps chromium

# wp-env 起動（.wp-env.override.json の 9151 ポート）
npx wp-env start

# e2e 実行
npm run test:e2e

# UI モードで確認したい場合
npm run test:e2e:ui
```

## 関連

- closes #125
- refs #123 / refs #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * Playwrightベースのエンドツーエンドテストを追加（JobPosting JSON-LD出力の検証を含む）。
  * テスト実行用のスクリプトと開発用テストユーティリティを追加。
* **Documentation**
  * READMEにE2Eテスト手順と環境変数によるホスト/ポート上書き方法を追記。
* **Chores**
  * CIでE2Eを実行し、HTMLレポートを成果物としてアップロード。テスト生成アーティファクトをignoreに追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->