### PR TITLE
[ 開発環境 ] PHPUnit・e2e テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -8,17 +8,15 @@ name: E2E Test
 # 既定の wp-env のポート（8889）を使うため、CI では http://localhost:8889 を渡す。
 
 on:
-    push:
-        branches:
-            - master
-            - develop
     pull_request:
         branches:
             - master
             - develop
+        types: [opened, reopened, labeled, synchronize]
 
 jobs:
     e2e:
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         name: Playwright e2e
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -1,18 +1,16 @@
 name: PHP Unit Test
 
 on:
-    push:
-        branches:
-            - master
-            - develop
     pull_request:
         branches:
             - master
             - develop
             - ^feature/.+
+        types: [opened, reopened, labeled, synchronize]
 
 jobs:
     php_unit:
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         name: php unit test
         runs-on: ubuntu-latest
         strategy:


### PR DESCRIPTION
## 概要

GitHub Actions の消費削減のため、PHPUnit と e2e(Playwright) のテストワークフローのトリガーを変更します。push での自動実行を廃止し、PR では `run-ci` ラベルが付いているときだけ実行するようにします。リリース時（release.yml）のテストは従来どおり維持します。

## 変更内容

- `.github/workflows/php_unit_test.yml`
  - `on.push` トリガーを削除
  - `on.pull_request.types` に `[opened, reopened, labeled, synchronize]` を追加
  - `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加
- `.github/workflows/e2e_test.yml`
  - `on.push` トリガーを削除
  - `on.pull_request.types` に `[opened, reopened, labeled, synchronize]` を追加
  - `e2e` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加

`release.yml`（リリース用）は対象外で変更していません。

## 確認手順

1. ラベル無しの PR ではワークフローが起動しない（ジョブがスキップされる）
2. `run-ci` ラベルを付与すると起動する
3. push では起動しない
4. リリース時（タグ push / release.yml）は従来どおりテストが走る

CI 設定のみでプラグイン動作に影響はありません。

関連: vektor-inc/multi-repo-tasks#24