### PR TITLE
[ 開発環境 ] リリースワークフローの wp-env override ファイル名を .wp-env.override.json に修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
               run: npm run dist
             - name: Setup wp-env override for dist
               run: |
-                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > wp-env.override.json
+                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > .wp-env.override.json
             - name: Start wp-env
               run: |
                   for n in 1 2 3; do npx wp-env start --update && break || [ "$n" -lt 3 ] || exit 1; done
@@ -86,9 +86,9 @@ jobs:
                     [ -f "$f" ] && cp "$f" "dist/${{ env.plugin_name }}/$f" || true
                   done
                   [ -d tests ] && cp -r tests "dist/${{ env.plugin_name }}/tests" || true
-            - name: Create wp-env.override.json for dist
+            - name: Create .wp-env.override.json for dist
               run: |
-                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > wp-env.override.json
+                  echo '{"plugins":["./dist/${{ env.plugin_name }}"]}' > .wp-env.override.json
             - name: Start wp-env
               run: |
                   for n in 1 2 3 4 5; do


### PR DESCRIPTION
## 概要

リリースワークフロー `.github/workflows/release.yml` の C-7 移行不備（親 issue vektor-inc/vk-agents#168 のフォローアップ）を修正します。

smoke_test / php_unit の2ジョブが wp-env の override 設定を `wp-env.override.json`（先頭ドット無し）というファイル名で生成していました。wp-env が読み込む override ファイルの正式名は `.wp-env.override.json`（先頭ドット有り）のため、この override は一切効いておらず、`.wp-env.json` の `"plugins": ["."]`（＝リポジトリ直下のソース）が検証対象になっていました。結果として、実際に配布される `dist/` 成果物ではなくソースを smoke test / phpunit で検証している状態でした。

該当2箇所の出力先を `.wp-env.override.json` にリネームし、override が正しく適用されて `./dist/vk-google-job-posting-manager`（実際にデプロイされる成果物）を検証するようにします。php_unit 側の step 名も実体に合わせて更新します。

## 変更内容

- `release.yml` smoke_test ジョブ: `> wp-env.override.json` → `> .wp-env.override.json`
- `release.yml` php_unit ジョブ: `> wp-env.override.json` → `> .wp-env.override.json`（step 名も `Create .wp-env.override.json for dist` に更新）

## 対応しなかった項目（検証済み）

issue のチェックリストのうち「WP-CLI 導入の要否」は **非該当**と判断し追加していません。

- `release.yml` が実行するのは `npm run dist`（smoke_test）と `npm run phpunit`（php_unit）のみ。
- `dist` の実行チェーン（`composer install` → `npm run build` → `bin/dist.sh`）に `wp` コマンド依存は無い（`build` は gulp `replace_text_domain` / `wp-scripts build`（＝`@wordpress/scripts` の node パッケージ、WP-CLI ではない）/ webpack / sass、`bin/dist.sh` は rsync + zip のみ）。
- `translate` スクリプトも `wp i18n make-pot` もリポジトリに存在しない。

## テスト（確認手順）

このワークフローは `on: push: tags: '[0-9]+.[0-9]+.[0-9]+'`（バージョンタグ push）でのみ起動するため、通常の PR CI では実行されません。次回リリース（タグ push）時に確認できます。

**変更が正しいことの確認（レビュー時）**

1. `.github/workflows/release.yml` の diff を確認する
   → override ファイルの出力先がすべて `.wp-env.override.json`（先頭ドット有り）になっていること。ドット無しの `wp-env.override.json` が残っていないこと。
2. リポジトリ直下に `.wp-env.override.json` が `.gitignore` 済みであることを確認する（CI 生成ファイルが誤コミットされないこと）。

**次回リリース時の確認（タグ push 後）**

1. バージョンタグ（例: `1.1.5`）を push し、Actions の「Deploy to WordPress.org」ワークフローを開く。
2. smoke_test / php_unit ジョブの「Start wp-env」以降のログで、`./dist/vk-google-job-posting-manager` がプラグインとして読み込まれていること（ソース直下 `.` ではないこと）を確認する。
   → dist 成果物に対して smoke test / phpunit が実行され、緑になること。

## 関連 issue

関連 issue: https://github.com/vektor-inc/vk-google-job-posting-manager/issues/137

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/275